### PR TITLE
Update engine tag

### DIFF
--- a/.project-metadata.yaml
+++ b/.project-metadata.yaml
@@ -8,7 +8,7 @@ date: "2021-07-06"
 engine_images:
   - image_name: engine
     tags:
-      - 14
+      - 14-cml-2021.05-1
 
 runtimes:
   - editor: Workbench


### PR DESCRIPTION
The `14` engine tag does not map to an actual image, and as such (in my testing, n=1 on CDP Public) this can't be deployed to an engine as is. It works with engines with the complete tag, like: `14-cml-2021.05-1`.

The (private) docs give an example with just `14`, so if this is changing, feel free to ignore!